### PR TITLE
Run prettier on staged files on commit

### DIFF
--- a/backend/.husky/pre-commit
+++ b/backend/.husky/pre-commit
@@ -1,0 +1,3 @@
+cd backend
+echo $PWD
+npx lint-staged

--- a/backend/.prettierrc
+++ b/backend/.prettierrc
@@ -1,3 +1,3 @@
 {
-    "tabWidth": 2
+  "tabWidth": 2
 }

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -31,6 +31,8 @@
         "@types/react": "^18.3.5",
         "cors": "^2.8.5",
         "cross-env": "^7.0.3",
+        "husky": "^9.1.7",
+        "lint-staged": "^15.4.3",
         "nodemon": "^3.1.9",
         "npm-run-all": "^4.1.5",
         "prettier": "3.3.3",
@@ -351,6 +353,22 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.0.0.tgz",
+      "integrity": "sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -595,6 +613,93 @@
         "node": ">= 6"
       }
     },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
+      "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^5.0.0",
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/emoji-regex": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -610,6 +715,23 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -876,6 +998,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -1026,6 +1161,37 @@
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
     "node_modules/express": {
@@ -1242,6 +1408,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.3.0.tgz",
+      "integrity": "sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
@@ -1258,6 +1437,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-symbol-description": {
@@ -1496,6 +1688,32 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {
@@ -1774,6 +1992,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-string": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
@@ -1981,6 +2212,201 @@
         }
       }
     },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lint-staged": {
+      "version": "15.4.3",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.4.3.tgz",
+      "integrity": "sha512-FoH1vOeouNh1pw+90S+cnuoFwRfUD9ijY2GKy5h7HS3OR7JVir2N2xrsa0+Twc1B7cW72L+88geG5cW4wIhn7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.4.1",
+        "commander": "^13.1.0",
+        "debug": "^4.4.0",
+        "execa": "^8.0.1",
+        "lilconfig": "^3.1.3",
+        "listr2": "^8.2.5",
+        "micromatch": "^4.0.8",
+        "pidtree": "^0.6.0",
+        "string-argv": "^0.3.2",
+        "yaml": "^2.7.0"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/lint-staged/node_modules/chalk": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/lint-staged/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lint-staged/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lint-staged/node_modules/pidtree": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
+      "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pidtree": "bin/pidtree.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-8.2.5.tgz",
+      "integrity": "sha512-iyAZCeyD+c1gPyE9qpFu8af0Y+MRtmKOncdGoA2S5EY8iFq99dmmvkNnHiWo+pj0s7yH7l3KPIgee77tKpXPWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^4.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/emoji-regex": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/listr2/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/listr2/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/wrap-ansi": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
+      "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/load-json-file": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -2030,6 +2456,144 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/emoji-regex": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.0.0.tgz",
+      "integrity": "sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.0.tgz",
+      "integrity": "sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
+      "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
     },
     "node_modules/loglevel": {
       "version": "1.9.2",
@@ -2119,6 +2683,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -2167,6 +2738,32 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimatch": {
@@ -2474,6 +3071,35 @@
         "which": "bin/which"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/oauth": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.10.0.tgz",
@@ -2557,6 +3183,22 @@
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/package-json-from-dist": {
@@ -3043,6 +3685,46 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/rimraf": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
@@ -3360,6 +4042,49 @@
         "node": ">=10"
       }
     },
+    "node_modules/slice-ansi": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.0.0",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/spdx-correct": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
@@ -3406,6 +4131,16 @@
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
       }
     },
     "node_modules/string-width": {
@@ -3572,6 +4307,19 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/supports-color": {
@@ -3959,6 +4707,19 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A=="
+    },
+    "node_modules/yaml": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
+      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     }
   }
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,6 +26,8 @@
     "@types/react": "^18.3.5",
     "cors": "^2.8.5",
     "cross-env": "^7.0.3",
+    "husky": "^9.1.7",
+    "lint-staged": "^15.4.3",
     "nodemon": "^3.1.9",
     "npm-run-all": "^4.1.5",
     "prettier": "3.3.3",
@@ -36,6 +38,11 @@
     "build": "tsc",
     "watch:build": "tsc --watch",
     "watch:server": "cross-env NODE_ENV=development nodemon --env-file=.env ./dist/index.js --watch ./dist",
-    "start": "npm-run-all clean build --parallel watch:build watch:server --print-label"
+    "start": "npm-run-all clean build --parallel watch:build watch:server --print-label",
+    "prepare": "cd .. && husky backend/.husky",
+    "format-all": "prettier . --write"
+  },
+  "lint-staged": {
+    "*": "prettier --ignore-unknown --write"
   }
 }

--- a/backend/src/db-functions/user.ts
+++ b/backend/src/db-functions/user.ts
@@ -6,9 +6,11 @@ import { db } from "../database";
  * @returns {Promise<Users>} A promise that resolves to the user object.
  * @throws {Error} If there is an error fetching the user.
  */
-export async function getUserById(
-  userId: number,
-): Promise<{ user_displayname: string; user_email: string, user_name: string | null }> {
+export async function getUserById(userId: number): Promise<{
+  user_displayname: string;
+  user_email: string;
+  user_name: string | null;
+}> {
   try {
     // Find the user by their user ID
     const result = await db
@@ -21,4 +23,3 @@ export async function getUserById(
     throw new Error("Error fetching user!");
   }
 }
-

--- a/backend/src/routers/api-router.ts
+++ b/backend/src/routers/api-router.ts
@@ -43,6 +43,6 @@ apiRouter.use("/search", searchRouter);
 apiRouter.use("/events", eventRouter);
 apiRouter.use("/tags", tagRouter);
 
-if (process.env.NODE_ENV === 'development') {
+if (process.env.NODE_ENV === "development") {
   apiRouter.use("/dev", devRouter);
 }

--- a/backend/src/routers/api-router/dev.ts
+++ b/backend/src/routers/api-router/dev.ts
@@ -1,106 +1,150 @@
-import { Router } from 'express';
-import { db } from '../../database';
-import { authMiddleware } from '../../middlewares/authMiddleware';
+import { Router } from "express";
+import { db } from "../../database";
+import { authMiddleware } from "../../middlewares/authMiddleware";
 
 export const devRouter = Router();
 
 // Clear database function
 async function clearDatabase() {
   // Delete in correct order to respect foreign key constraints
-  await db.deleteFrom('eventtags').execute();
-  await db.deleteFrom('orgtags').execute();
-  await db.deleteFrom('eventorgs').execute();
-  await db.deleteFrom('savedevents').execute();
-  await db.deleteFrom('userlikes').execute();
-  await db.deleteFrom('userattendance').execute();
-  await db.deleteFrom('usersubs').execute();
-  await db.deleteFrom('userorgs').execute();
-  await db.deleteFrom('alternateorgnames').execute();
-  await db.deleteFrom('reports').execute();
-  await db.deleteFrom('events').execute();
-  await db.deleteFrom('orgs').execute();
-  await db.deleteFrom('tags').execute();
+  await db.deleteFrom("eventtags").execute();
+  await db.deleteFrom("orgtags").execute();
+  await db.deleteFrom("eventorgs").execute();
+  await db.deleteFrom("savedevents").execute();
+  await db.deleteFrom("userlikes").execute();
+  await db.deleteFrom("userattendance").execute();
+  await db.deleteFrom("usersubs").execute();
+  await db.deleteFrom("userorgs").execute();
+  await db.deleteFrom("alternateorgnames").execute();
+  await db.deleteFrom("reports").execute();
+  await db.deleteFrom("events").execute();
+  await db.deleteFrom("orgs").execute();
+  await db.deleteFrom("tags").execute();
 }
 
 // Clear database endpoint
-devRouter.post('/clear', authMiddleware, async (req, res) => {
+devRouter.post("/clear", authMiddleware, async (req, res) => {
   try {
     await clearDatabase();
-    res.json({ message: 'Database cleared successfully (excluding users)' });
+    res.json({ message: "Database cleared successfully (excluding users)" });
   } catch (error) {
-    console.error('Error clearing database:', error);
-    res.status(500).json({ error: 'Failed to clear database' });
+    console.error("Error clearing database:", error);
+    res.status(500).json({ error: "Failed to clear database" });
   }
 });
 
-devRouter.post('/populate', authMiddleware, async (req, res) => {
+devRouter.post("/populate", authMiddleware, async (req, res) => {
   try {
     const user_id = req.user?.user_id;
 
     if (!user_id) {
-      res.status(401).json({ error: 'Unauthorized' });
+      res.status(401).json({ error: "Unauthorized" });
       return;
     }
 
     // First, create sample tags
     const sampleTags = [
       // Event Types
-      { tag_name: 'Workshop', tag_description: 'Hands-on learning sessions', tag_official: true },
-      { tag_name: 'Career Fair', tag_description: 'Professional networking and job opportunities', tag_official: true },
-      { tag_name: 'Social', tag_description: 'Social gatherings and meetups', tag_official: true },
-      { tag_name: 'Academic', tag_description: 'Academic-focused events', tag_official: true },
-      { tag_name: 'Sports', tag_description: 'Athletic events and activities', tag_official: true },
-      { tag_name: 'Free Food', tag_description: 'Events with complimentary food', tag_official: true },
-      { tag_name: 'Performance', tag_description: 'Live performances and shows', tag_official: true },
-      { tag_name: 'Seminar', tag_description: 'Educational presentations', tag_official: true },
-      
+      {
+        tag_name: "Workshop",
+        tag_description: "Hands-on learning sessions",
+        tag_official: true,
+      },
+      {
+        tag_name: "Career Fair",
+        tag_description: "Professional networking and job opportunities",
+        tag_official: true,
+      },
+      {
+        tag_name: "Social",
+        tag_description: "Social gatherings and meetups",
+        tag_official: true,
+      },
+      {
+        tag_name: "Academic",
+        tag_description: "Academic-focused events",
+        tag_official: true,
+      },
+      {
+        tag_name: "Sports",
+        tag_description: "Athletic events and activities",
+        tag_official: true,
+      },
+      {
+        tag_name: "Free Food",
+        tag_description: "Events with complimentary food",
+        tag_official: true,
+      },
+      {
+        tag_name: "Performance",
+        tag_description: "Live performances and shows",
+        tag_official: true,
+      },
+      {
+        tag_name: "Seminar",
+        tag_description: "Educational presentations",
+        tag_official: true,
+      },
+
       // Academic Areas
-      { tag_name: 'Engineering', tag_description: 'Engineering-related events', tag_official: true },
-      { tag_name: 'Business', tag_description: 'Business-focused events', tag_official: true },
-      { tag_name: 'Arts', tag_description: 'Arts and creative events', tag_official: true },
-      { tag_name: 'Science', tag_description: 'Science-related events', tag_official: true }
+      {
+        tag_name: "Engineering",
+        tag_description: "Engineering-related events",
+        tag_official: true,
+      },
+      {
+        tag_name: "Business",
+        tag_description: "Business-focused events",
+        tag_official: true,
+      },
+      {
+        tag_name: "Arts",
+        tag_description: "Arts and creative events",
+        tag_official: true,
+      },
+      {
+        tag_name: "Science",
+        tag_description: "Science-related events",
+        tag_official: true,
+      },
     ];
 
     // Insert tags
     for (const tag of sampleTags) {
-      await db.insertInto('tags')
-        .values(tag)
-        .execute();
+      await db.insertInto("tags").values(tag).execute();
     }
 
     // Create sample organizations
     const sampleOrgs = [
       {
-        org_name: 'Engineering Student Council',
-        org_email: 'esc@tamu.edu',
-        org_description: 'The voice of engineering students at TAMU',
-        org_building: 'ZACH',
-        org_room: '401',
-        org_verified: true
+        org_name: "Engineering Student Council",
+        org_email: "esc@tamu.edu",
+        org_description: "The voice of engineering students at TAMU",
+        org_building: "ZACH",
+        org_room: "401",
+        org_verified: true,
       },
       {
-        org_name: 'MSC Town Hall',
-        org_email: 'townhall@tamu.edu',
-        org_description: 'Bringing entertainment to campus',
-        org_building: 'MSC',
-        org_room: '2406',
-        org_verified: true
+        org_name: "MSC Town Hall",
+        org_email: "townhall@tamu.edu",
+        org_description: "Bringing entertainment to campus",
+        org_building: "MSC",
+        org_room: "2406",
+        org_verified: true,
       },
       {
-        org_name: 'TAMU Computing Society',
-        org_email: 'tacs@tamu.edu',
-        org_description: 'Computing enthusiasts unite',
-        org_building: 'PETR',
-        org_room: '207',
-        org_verified: true
-      }
+        org_name: "TAMU Computing Society",
+        org_email: "tacs@tamu.edu",
+        org_description: "Computing enthusiasts unite",
+        org_building: "PETR",
+        org_room: "207",
+        org_verified: true,
+      },
     ];
 
     // Insert organizations
     for (const org of sampleOrgs) {
-      await db.insertInto('orgs')
-        .values(org)
-        .execute();
+      await db.insertInto("orgs").values(org).execute();
     }
 
     // Create sample events
@@ -109,115 +153,147 @@ devRouter.post('/populate', authMiddleware, async (req, res) => {
       // Career Events
       {
         contributor_id: user_id,
-        event_name: 'Engineering Career Fair',
-        event_description: 'Fall 2024 Engineering Career Fair - Meet top employers in engineering fields',
-        event_location: 'Reed Arena',
+        event_name: "Engineering Career Fair",
+        event_description:
+          "Fall 2024 Engineering Career Fair - Meet top employers in engineering fields",
+        event_location: "Reed Arena",
         start_time: new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000),
-        end_time: new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000 + 8 * 60 * 60 * 1000),
+        end_time: new Date(
+          now.getTime() + 7 * 24 * 60 * 60 * 1000 + 8 * 60 * 60 * 1000,
+        ),
       },
       {
         contributor_id: user_id,
-        event_name: 'Business Career Fair',
-        event_description: 'Connect with leading companies in business, finance, and consulting',
-        event_location: 'MSC Bethancourt Ballroom',
+        event_name: "Business Career Fair",
+        event_description:
+          "Connect with leading companies in business, finance, and consulting",
+        event_location: "MSC Bethancourt Ballroom",
         start_time: new Date(now.getTime() + 14 * 24 * 60 * 60 * 1000),
-        end_time: new Date(now.getTime() + 14 * 24 * 60 * 60 * 1000 + 6 * 60 * 60 * 1000),
+        end_time: new Date(
+          now.getTime() + 14 * 24 * 60 * 60 * 1000 + 6 * 60 * 60 * 1000,
+        ),
       },
 
       // Workshops
       {
         contributor_id: user_id,
-        event_name: 'Python Programming Workshop',
-        event_description: 'Learn the basics of Python programming with hands-on exercises',
-        event_location: 'ZACH 310',
+        event_name: "Python Programming Workshop",
+        event_description:
+          "Learn the basics of Python programming with hands-on exercises",
+        event_location: "ZACH 310",
         start_time: new Date(now.getTime() + 3 * 24 * 60 * 60 * 1000),
-        end_time: new Date(now.getTime() + 3 * 24 * 60 * 60 * 1000 + 2 * 60 * 60 * 1000),
+        end_time: new Date(
+          now.getTime() + 3 * 24 * 60 * 60 * 1000 + 2 * 60 * 60 * 1000,
+        ),
       },
       {
         contributor_id: user_id,
-        event_name: 'Resume Writing Workshop',
-        event_description: 'Learn how to craft an effective resume with industry experts',
-        event_location: 'MSC 2406',
+        event_name: "Resume Writing Workshop",
+        event_description:
+          "Learn how to craft an effective resume with industry experts",
+        event_location: "MSC 2406",
         start_time: new Date(now.getTime() + 5 * 24 * 60 * 60 * 1000),
-        end_time: new Date(now.getTime() + 5 * 24 * 60 * 60 * 1000 + 1.5 * 60 * 60 * 1000),
+        end_time: new Date(
+          now.getTime() + 5 * 24 * 60 * 60 * 1000 + 1.5 * 60 * 60 * 1000,
+        ),
       },
 
       // Social Events
       {
         contributor_id: user_id,
-        event_name: 'Movie Night: Inception',
-        event_description: 'Watch Inception with free pizza and drinks',
-        event_location: 'MSC 2406',
+        event_name: "Movie Night: Inception",
+        event_description: "Watch Inception with free pizza and drinks",
+        event_location: "MSC 2406",
         start_time: new Date(now.getTime() + 24 * 60 * 60 * 1000),
-        end_time: new Date(now.getTime() + 24 * 60 * 60 * 1000 + 3 * 60 * 60 * 1000),
+        end_time: new Date(
+          now.getTime() + 24 * 60 * 60 * 1000 + 3 * 60 * 60 * 1000,
+        ),
       },
       {
         contributor_id: user_id,
-        event_name: 'Game Night',
-        event_description: 'Join us for board games, video games, and snacks',
-        event_location: 'Commons',
+        event_name: "Game Night",
+        event_description: "Join us for board games, video games, and snacks",
+        event_location: "Commons",
         start_time: new Date(now.getTime() + 4 * 24 * 60 * 60 * 1000),
-        end_time: new Date(now.getTime() + 4 * 24 * 60 * 60 * 1000 + 4 * 60 * 60 * 1000),
+        end_time: new Date(
+          now.getTime() + 4 * 24 * 60 * 60 * 1000 + 4 * 60 * 60 * 1000,
+        ),
       },
 
       // Academic Events
       {
         contributor_id: user_id,
-        event_name: 'Research Symposium',
-        event_description: 'Annual research showcase featuring student projects',
-        event_location: 'MSC Bethancourt Ballroom',
+        event_name: "Research Symposium",
+        event_description:
+          "Annual research showcase featuring student projects",
+        event_location: "MSC Bethancourt Ballroom",
         start_time: new Date(now.getTime() + 10 * 24 * 60 * 60 * 1000),
-        end_time: new Date(now.getTime() + 10 * 24 * 60 * 60 * 1000 + 8 * 60 * 60 * 1000),
+        end_time: new Date(
+          now.getTime() + 10 * 24 * 60 * 60 * 1000 + 8 * 60 * 60 * 1000,
+        ),
       },
       {
         contributor_id: user_id,
-        event_name: 'Guest Lecture: AI Ethics',
-        event_description: 'Distinguished lecture on ethical considerations in AI development',
-        event_location: 'ZACH 350',
+        event_name: "Guest Lecture: AI Ethics",
+        event_description:
+          "Distinguished lecture on ethical considerations in AI development",
+        event_location: "ZACH 350",
         start_time: new Date(now.getTime() + 6 * 24 * 60 * 60 * 1000),
-        end_time: new Date(now.getTime() + 6 * 24 * 60 * 60 * 1000 + 1.5 * 60 * 60 * 1000),
+        end_time: new Date(
+          now.getTime() + 6 * 24 * 60 * 60 * 1000 + 1.5 * 60 * 60 * 1000,
+        ),
       },
 
       // Sports Events
       {
         contributor_id: user_id,
-        event_name: 'Intramural Soccer Tournament',
-        event_description: 'Annual soccer tournament open to all skill levels',
-        event_location: 'Penberthy Fields',
+        event_name: "Intramural Soccer Tournament",
+        event_description: "Annual soccer tournament open to all skill levels",
+        event_location: "Penberthy Fields",
         start_time: new Date(now.getTime() + 8 * 24 * 60 * 60 * 1000),
-        end_time: new Date(now.getTime() + 8 * 24 * 60 * 60 * 1000 + 6 * 60 * 60 * 1000),
+        end_time: new Date(
+          now.getTime() + 8 * 24 * 60 * 60 * 1000 + 6 * 60 * 60 * 1000,
+        ),
       },
       {
         contributor_id: user_id,
-        event_name: 'Basketball Tournament',
-        event_description: '3v3 basketball tournament with prizes',
-        event_location: 'Student Rec Center',
+        event_name: "Basketball Tournament",
+        event_description: "3v3 basketball tournament with prizes",
+        event_location: "Student Rec Center",
         start_time: new Date(now.getTime() + 9 * 24 * 60 * 60 * 1000),
-        end_time: new Date(now.getTime() + 9 * 24 * 60 * 60 * 1000 + 5 * 60 * 60 * 1000),
+        end_time: new Date(
+          now.getTime() + 9 * 24 * 60 * 60 * 1000 + 5 * 60 * 60 * 1000,
+        ),
       },
 
       // Performance Events
       {
         contributor_id: user_id,
-        event_name: 'Spring Concert',
-        event_description: 'Annual spring concert featuring student performers',
-        event_location: 'Rudder Auditorium',
+        event_name: "Spring Concert",
+        event_description: "Annual spring concert featuring student performers",
+        event_location: "Rudder Auditorium",
         start_time: new Date(now.getTime() + 15 * 24 * 60 * 60 * 1000),
-        end_time: new Date(now.getTime() + 15 * 24 * 60 * 60 * 1000 + 3 * 60 * 60 * 1000),
+        end_time: new Date(
+          now.getTime() + 15 * 24 * 60 * 60 * 1000 + 3 * 60 * 60 * 1000,
+        ),
       },
       {
         contributor_id: user_id,
-        event_name: 'Theater Performance',
-        event_description: 'Student theater production of "A Midsummer Night\'s Dream"',
-        event_location: 'Rudder Theater',
+        event_name: "Theater Performance",
+        event_description:
+          'Student theater production of "A Midsummer Night\'s Dream"',
+        event_location: "Rudder Theater",
         start_time: new Date(now.getTime() + 12 * 24 * 60 * 60 * 1000),
-        end_time: new Date(now.getTime() + 12 * 24 * 60 * 60 * 1000 + 2.5 * 60 * 60 * 1000),
-      }
+        end_time: new Date(
+          now.getTime() + 12 * 24 * 60 * 60 * 1000 + 2.5 * 60 * 60 * 1000,
+        ),
+      },
     ];
 
     // Insert events and their tags
     for (const event of sampleEvents) {
-      const insertedEvent = await db.insertInto('events')
+      const insertedEvent = await db
+        .insertInto("events")
         .values(event)
         .returningAll()
         .executeTakeFirst();
@@ -225,41 +301,58 @@ devRouter.post('/populate', authMiddleware, async (req, res) => {
       if (!insertedEvent) continue;
 
       // Add relevant tags to each event
-      if (event.event_name.includes('Career Fair')) {
-        await addEventTags(insertedEvent.event_id, ['Career Fair', event.event_name.includes('Engineering') ? 'Engineering' : 'Business']);
-      } else if (event.event_name.includes('Workshop')) {
-        await addEventTags(insertedEvent.event_id, ['Workshop', event.event_name.includes('Python') ? 'Engineering' : 'Academic']);
-      } else if (event.event_name.includes('Movie') || event.event_name.includes('Game')) {
-        await addEventTags(insertedEvent.event_id, ['Social', 'Free Food']);
-      } else if (event.event_name.includes('Research') || event.event_name.includes('Lecture')) {
-        await addEventTags(insertedEvent.event_id, ['Academic', 'Seminar']);
-      } else if (event.event_name.includes('Tournament')) {
-        await addEventTags(insertedEvent.event_id, ['Sports']);
-      } else if (event.event_name.includes('Concert') || event.event_name.includes('Theater')) {
-        await addEventTags(insertedEvent.event_id, ['Performance', 'Arts']);
+      if (event.event_name.includes("Career Fair")) {
+        await addEventTags(insertedEvent.event_id, [
+          "Career Fair",
+          event.event_name.includes("Engineering") ? "Engineering" : "Business",
+        ]);
+      } else if (event.event_name.includes("Workshop")) {
+        await addEventTags(insertedEvent.event_id, [
+          "Workshop",
+          event.event_name.includes("Python") ? "Engineering" : "Academic",
+        ]);
+      } else if (
+        event.event_name.includes("Movie") ||
+        event.event_name.includes("Game")
+      ) {
+        await addEventTags(insertedEvent.event_id, ["Social", "Free Food"]);
+      } else if (
+        event.event_name.includes("Research") ||
+        event.event_name.includes("Lecture")
+      ) {
+        await addEventTags(insertedEvent.event_id, ["Academic", "Seminar"]);
+      } else if (event.event_name.includes("Tournament")) {
+        await addEventTags(insertedEvent.event_id, ["Sports"]);
+      } else if (
+        event.event_name.includes("Concert") ||
+        event.event_name.includes("Theater")
+      ) {
+        await addEventTags(insertedEvent.event_id, ["Performance", "Arts"]);
       }
     }
 
-    res.json({ message: 'Sample data populated successfully' });
+    res.json({ message: "Sample data populated successfully" });
   } catch (error) {
-    console.error('Error populating sample data:', error);
-    res.status(500).json({ error: 'Failed to populate sample data' });
+    console.error("Error populating sample data:", error);
+    res.status(500).json({ error: "Failed to populate sample data" });
   }
 });
 
 async function addEventTags(eventId: number, tagNames: string[]) {
   // Get tag IDs
-  const tags = await db.selectFrom('tags')
-    .select(['tag_id'])
-    .where('tag_name', 'in', tagNames)
+  const tags = await db
+    .selectFrom("tags")
+    .select(["tag_id"])
+    .where("tag_name", "in", tagNames)
     .execute();
 
   // Add tags to event
   for (const tag of tags) {
-    await db.insertInto('eventtags')
+    await db
+      .insertInto("eventtags")
       .values({
         event_id: eventId,
-        tag_id: tag.tag_id
+        tag_id: tag.tag_id,
       })
       .execute();
   }

--- a/backend/src/routers/api-router/users.ts
+++ b/backend/src/routers/api-router/users.ts
@@ -37,7 +37,11 @@ usersRouter.post("/", authMiddleware, async (req, res) => {
   try {
     await db
       .insertInto("users")
-      .values({ user_name: username, user_email: email, user_displayname: username })
+      .values({
+        user_name: username,
+        user_email: email,
+        user_displayname: username,
+      })
       .execute();
     res.send("User created!");
   } catch (error) {
@@ -100,9 +104,9 @@ usersRouter.post("/exists", async (req, res) => {
   const { username } = req.body;
 
   if (!username || typeof username !== "string") {
-    return res.status(400).json({ 
+    return res.status(400).json({
       message: "Username is required",
-      exists: false 
+      exists: false,
     });
   }
 
@@ -113,15 +117,16 @@ usersRouter.post("/exists", async (req, res) => {
       .select("user_id")
       .executeTakeFirst();
 
-    res.json({ 
+    res.json({
       exists: user !== undefined,
-      message: user !== undefined ? "Username is taken" : "Username is available"
+      message:
+        user !== undefined ? "Username is taken" : "Username is available",
     });
   } catch (error) {
     console.error("Error checking username:", error);
-    res.status(500).json({ 
+    res.status(500).json({
       message: "Error checking username",
-      exists: false 
+      exists: false,
     });
   }
 });
@@ -131,7 +136,7 @@ usersRouter.post("/validate", async (req, res) => {
   if (!username || typeof username !== "string") {
     return res.status(400).json({
       message: "Username is required",
-      isValid: false
+      isValid: false,
     });
   }
 
@@ -139,19 +144,19 @@ usersRouter.post("/validate", async (req, res) => {
   if (username.length > 20 || username.length < 3) {
     return res.status(400).json({
       isValid: false,
-      message: "Username is too long"
+      message: "Username is too long",
     });
   }
   if (!/^[a-zA-Z0-9]+$/.test(username)) {
     return res.status(400).json({
       isValid: false,
-      message: "Username must be alphanumeric"
+      message: "Username must be alphanumeric",
     });
   }
-      return res.json({
-        isValid: true,
-        message: "Username is valid"
-  })
+  return res.json({
+    isValid: true,
+    message: "Username is valid",
+  });
 });
 
 /**
@@ -210,7 +215,7 @@ usersRouter.get("/:username", async (req, res) => {
       .selectAll()
       .executeTakeFirst();
 
-    if (!user) {  
+    if (!user) {
       return res.status(404).json({ message: "User not found" });
     }
 
@@ -282,17 +287,12 @@ usersRouter.get("/:username/profile", async (req, res) => {
       .selectFrom("userorgs as uo")
       .where("uo.user_id", "=", user.user_id)
       .innerJoin("orgs as o", "uo.org_id", "o.org_id")
-      .select([
-        "o.org_id",
-        "o.org_name",
-        "o.org_description",
-        "o.org_icon",
-      ])
+      .select(["o.org_id", "o.org_name", "o.org_description", "o.org_icon"])
       .execute();
 
     // Process events to group tags
     const processedEvents = events.reduce((acc: any[], event) => {
-      const existingEvent = acc.find(e => e.event_id === event.event_id);
+      const existingEvent = acc.find((e) => e.event_id === event.event_id);
       if (existingEvent) {
         if (event.tag_name && !existingEvent.tags.includes(event.tag_name)) {
           existingEvent.tags.push(event.tag_name);

--- a/backend/src/routers/auth-router.ts
+++ b/backend/src/routers/auth-router.ts
@@ -29,7 +29,7 @@ authRouter.get("/user", async (req, res) => {
 authRouter.get(
   "/google",
   passport.authenticate("google", {
-    scope: ["profile", "email"],  
+    scope: ["profile", "email"],
   }),
 );
 

--- a/backend/src/types/events.ts
+++ b/backend/src/types/events.ts
@@ -1,23 +1,23 @@
 import { EventStatus } from "./schema";
 
 export interface EventInfo {
-    event_id: number; 
-    event_name: string; 
-    event_description: string | null; 
-    event_location: string | null; 
-    event_img: string | null;
-    event_status: EventStatus;
+  event_id: number;
+  event_name: string;
+  event_description: string | null;
+  event_location: string | null;
+  event_img: string | null;
+  event_status: EventStatus;
 
-    event_views: number; 
-    event_likes: number;
-    event_going: number;
+  event_views: number;
+  event_likes: number;
+  event_going: number;
 
-    start_time: Date; 
-    end_time: Date; 
-    date_created: Date; 
-    date_modified: Date; 
+  start_time: Date;
+  end_time: Date;
+  date_created: Date;
+  date_modified: Date;
 
-    contributor_name: string; 
-    org_name: string | null; 
-    tags: string[]; 
+  contributor_name: string;
+  org_name: string | null;
+  tags: string[];
 }

--- a/backend/src/types/schema.ts
+++ b/backend/src/types/schema.ts
@@ -12,9 +12,9 @@ export type Generated<T> =
 
 export type Timestamp = ColumnType<Date, Date | string, Date | string>;
 
-export type EventStatus = 'draft' | 'published' | 'cancelled';
-export type FriendshipStatus = 'pending' | 'accepted' | 'rejected' | 'blocked';
-export type ReportStatus = 'pending' | 'reviewed' | 'resolved' | 'rejected';
+export type EventStatus = "draft" | "published" | "cancelled";
+export type FriendshipStatus = "pending" | "accepted" | "rejected" | "blocked";
+export type ReportStatus = "pending" | "reviewed" | "resolved" | "rejected";
 
 export interface Alternateorgnames {
   alternate_name_id: Generated<number>;

--- a/backend/src/utils/rate-limiter.ts
+++ b/backend/src/utils/rate-limiter.ts
@@ -1,7 +1,7 @@
-import { rateLimit } from 'express-rate-limit'
+import { rateLimit } from "express-rate-limit";
 
 export const limiter = rateLimit({
-    windowMs: 15 * 60 * 1000,
-    max: 100,
-    message: 'Too many requests from this IP, please try again after 15 minutes'
-})
+  windowMs: 15 * 60 * 1000,
+  max: 100,
+  message: "Too many requests from this IP, please try again after 15 minutes",
+});

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,14 +1,12 @@
 {
-    "compilerOptions": {
-      "target": "ES6",                // The JavaScript version to compile to (e.g., ES5, ES6)
-      "module": "commonjs",            // The module system (e.g., commonjs, es6)
-      "outDir": "./dist",              // Output directory for compiled JS files
-      "rootDir": "./src",              // Root directory for TypeScript files
-      "strict": true,                  // Enable strict type-checking options
-      "esModuleInterop": true,          // Allow default imports from modules
-    },
-    "include": ["src/**/*",
-    "**/*.ts",
-    "**/*.tsx"],           // Specify files or directories to include
-    "exclude": ["node_modules"]        // Specify files or directories to exclude
- }
+  "compilerOptions": {
+    "target": "ES6", // The JavaScript version to compile to (e.g., ES5, ES6)
+    "module": "commonjs", // The module system (e.g., commonjs, es6)
+    "outDir": "./dist", // Output directory for compiled JS files
+    "rootDir": "./src", // Root directory for TypeScript files
+    "strict": true, // Enable strict type-checking options
+    "esModuleInterop": true // Allow default imports from modules
+  },
+  "include": ["src/**/*", "**/*.ts", "**/*.tsx"], // Specify files or directories to include
+  "exclude": ["node_modules"] // Specify files or directories to exclude
+}


### PR DESCRIPTION
Uses [Husky](https://typicode.github.io/husky/) as the pre-commit manager to run [lint-staged](https://github.com/lint-staged/lint-staged) which then calls [Prettier](https://prettier.io/) on all staged files

Add a `format-all` script (invoked using `npm run format-all`) to format all files in `.`

Format all files in the `backend/` directory through Prettier